### PR TITLE
RIA-4617 requestHearingRequirementsFeature event added to Judge

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -122,6 +122,8 @@ security:
     - "rollbackPayment"
     - "rollbackPaymentTimeout"
     - "rollbackPaymentTimeoutToPaymentPending"
+    caseworker-ia-iacjudge:
+      - "requestHearingRequirementsFeature"
 
 auth.provider.service.client.baseUrl: ${S2S_URL:http://127.0.0.1:4502}
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
[RIA-4617](https://tools.hmcts.net/jira/browse/RIA-4617)


### Change description ###
When the Judge makes sendDirection event after requestResponseReview state is triggering a callback error from the TimedEventService. This is due to the Judge not having the permission to the requestHearingRequirementsFeature event.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```