### PR TITLE
RIA-7383 - preventing application startup if secrets can't be found

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -27,7 +27,9 @@ def secrets = [
         secret('test-law-firm-a-username', 'TEST_LAW_FIRM_A_USERNAME'),
         secret('test-law-firm-a-password', 'TEST_LAW_FIRM_A_PASSWORD'),
         secret('test-homeoffice-lart-username', 'TEST_HOMEOFFICE_LART_USERNAME'),
-        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD')
+        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD'),
+
+        secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
     ]
 ]
 

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -33,7 +33,9 @@ def secrets = [
         secret('test-law-firm-a-username', 'TEST_LAW_FIRM_A_USERNAME'),
         secret('test-law-firm-a-password', 'TEST_LAW_FIRM_A_PASSWORD'),
         secret('test-homeoffice-lart-username', 'TEST_HOMEOFFICE_LART_USERNAME'),
-        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD')
+        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD'),
+
+        secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
     ]
 ]
 

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -29,7 +29,9 @@ def secrets = [
         secret('test-law-firm-a-username', 'TEST_LAW_FIRM_A_USERNAME'),
         secret('test-law-firm-a-password', 'TEST_LAW_FIRM_A_PASSWORD'),
         secret('test-homeoffice-lart-username', 'TEST_HOMEOFFICE_LART_USERNAME'),
-        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD')
+        secret('test-homeoffice-lart-password', 'TEST_HOMEOFFICE_LART_PASSWORD'),
+
+        secret('ia-config-validator-secret', 'IA_CONFIG_VALIDATOR_SECRET')
     ]
 ]
 

--- a/charts/ia-timed-event-service/Chart.yaml
+++ b/charts/ia-timed-event-service/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for ia-timed-event-service App
 name: ia-timed-event-service
 home: https://github.com/hmcts/ia-timed-event-service
-version: 0.0.21
+version: 0.0.22
 maintainers:
   - name: HMCTS Immigration & Asylum Team
     email: ImmigrationandAsylum@HMCTS.NET

--- a/charts/ia-timed-event-service/values.preview.template.yaml
+++ b/charts/ia-timed-event-service/values.preview.template.yaml
@@ -23,5 +23,6 @@ java:
         - s2s-secret
         - s2s-microservice
         - AppInsightsInstrumentationKey
+        - ia-config-validator-secret
   postgresql:
     enabled: true

--- a/charts/ia-timed-event-service/values.yaml
+++ b/charts/ia-timed-event-service/values.yaml
@@ -31,3 +31,4 @@ java:
         - s2s-microservice
         - AppInsightsInstrumentationKey
         - timed-event-service-POSTGRES-PASS-11
+        - ia-config-validator-secret

--- a/src/main/java/uk/gov/hmcts/reform/timedevent/infrastructure/ConfigValidatorAppListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/timedevent/infrastructure/ConfigValidatorAppListener.java
@@ -1,0 +1,50 @@
+package uk.gov.hmcts.reform.timedevent.infrastructure;
+
+import com.microsoft.applicationinsights.boot.dependencies.apachecommons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.event.ContextRefreshedEvent;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+@Getter
+@Setter
+public class ConfigValidatorAppListener implements ApplicationListener<ContextRefreshedEvent> {
+
+    protected static final String CLUSTER_NAME = "CLUSTER_NAME";
+
+    @Autowired
+    private Environment environment;
+
+    @Value("${ia.config.validator.secret}")
+    private String iaConfigValidatorSecret;
+
+    @Override
+    public void onApplicationEvent(ContextRefreshedEvent event) {
+        breakOnMissingIaConfigValidatorSecret();
+    }
+
+    void breakOnMissingIaConfigValidatorSecret() {
+        String clusterName = environment.getProperty(CLUSTER_NAME);
+        log.info("{} value: {}", CLUSTER_NAME, clusterName);
+        if (StringUtils.isBlank(clusterName)) {
+            log.warn("{} is null or empty. Skipping this check. This is allowed on a developer's local environment "
+                + "but not on a cluster. If you are in a cluster, this warning is going to be a problem.",
+                     CLUSTER_NAME);
+            return;
+        }
+
+        if (StringUtils.isBlank(iaConfigValidatorSecret)) {
+            throw new IllegalArgumentException("ia.config.validator.secret is null or empty."
+                + " This is not allowed and it will break production. This is a secret value stored in a vault"
+                + " (unless running locally). Check application.yaml for further information.");
+        }
+    }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -151,3 +151,8 @@ idam:
 ccd:
   case-data-api:
     url: ${CCD_URL:http://127.0.0.1:4452}
+
+ia:
+  config:
+    validator:
+      secret: ${IA_CONFIG_VALIDATOR_SECRET:}

--- a/src/main/resources/bootstrap.yaml
+++ b/src/main/resources/bootstrap.yaml
@@ -13,3 +13,4 @@ spring:
         s2s-microservice: IA_S2S_MICROSERVICE
         timed-event-service-POSTGRES-PASS-11: spring.datasource.password
         AppInsightsInstrumentationKey: azure.application-insights.instrumentation-key
+        ia-config-validator-secret: IA_CONFIG_VALIDATOR_SECRET

--- a/src/test/java/uk/gov/hmcts/reform/timedevent/infrastructure/ConfigValidatorAppListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/timedevent/infrastructure/ConfigValidatorAppListenerTest.java
@@ -1,0 +1,111 @@
+package uk.gov.hmcts.reform.timedevent.infrastructure;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.env.Environment;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.hmcts.reform.timedevent.infrastructure.ConfigValidatorAppListener.CLUSTER_NAME;
+
+@ExtendWith(MockitoExtension.class)
+class ConfigValidatorAppListenerTest {
+
+    @Mock
+    private Environment env;
+
+    private ConfigValidatorAppListener configValidatorAppListener;
+
+    @BeforeEach
+    public void setup() {
+        configValidatorAppListener = new ConfigValidatorAppListener();
+        configValidatorAppListener.setEnvironment(env);
+    }
+
+    @Test
+    @SuppressWarnings("java:S2699")
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsNullSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret(null);
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    @Test
+    void throwsExceptionWhenIaConfigValidatorSecretIsEmptySimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+
+        // When/Then
+        assertThrows(IllegalArgumentException.class, configValidatorAppListener::breakOnMissingIaConfigValidatorSecret);
+        verify(env).getProperty(CLUSTER_NAME);
+    }
+
+    // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    @Test
+    @SuppressWarnings("java:S2699")
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateLocal() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn(null);
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+        // I run successfully till the end
+    }
+
+    // suppressing SonarLint warning on assertions as it's ok for this test not to have any
+    @Test
+    @SuppressWarnings("java:S2699")
+    void runsSuccessfullyWhenIaConfigValidatorSecretsAreCorrectlySetSimulateCluster() {
+        // Given
+        configValidatorAppListener.setIaConfigValidatorSecret("secret");
+        when(env.getProperty(CLUSTER_NAME)).thenReturn("cft-preview-01-aks");
+
+        // When
+        configValidatorAppListener.breakOnMissingIaConfigValidatorSecret();
+
+        // Then
+        verify(env).getProperty(CLUSTER_NAME);
+        // I run successfully till the end
+    }
+
+}


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RIA-7383


### Change description ###
Adding ia.config.validator.secret to application.yaml + ConfigValidatorAppListener to check to see if secrets are being applied by azure.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
