### PR TITLE
DIAC-835 Update reschedule event

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/timedevent/infrastructure/security/CcdEventAuthorizor.java
+++ b/src/main/java/uk/gov/hmcts/reform/timedevent/infrastructure/security/CcdEventAuthorizor.java
@@ -5,12 +5,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import uk.gov.hmcts.reform.timedevent.infrastructure.domain.entities.ccd.Event;
 
-@Slf4j
 public class CcdEventAuthorizor {
 
     private final Map<String, List<Event>> roleEventAccess;
@@ -25,11 +22,6 @@ public class CcdEventAuthorizor {
 
         List<String> requiredRoles = getRequiredRolesForEvent(event);
         Set<String> userRoles = authorizedRolesProvider.getRoles();
-        // TODO: delete log
-        log.info("Required user roles oles for event '{}' - {}, Current user roles: {}",
-                event.name(),
-                String.join(",", requiredRoles),
-                String.join(",", userRoles));
 
         if (requiredRoles.isEmpty()
             || userRoles.isEmpty()

--- a/src/main/java/uk/gov/hmcts/reform/timedevent/infrastructure/services/quartz/RetryJobListener.java
+++ b/src/main/java/uk/gov/hmcts/reform/timedevent/infrastructure/services/quartz/RetryJobListener.java
@@ -1,5 +1,6 @@
 package uk.gov.hmcts.reform.timedevent.infrastructure.services.quartz;
 
+import java.security.SecureRandom;
 import java.time.ZonedDateTime;
 import lombok.extern.slf4j.Slf4j;
 import org.quartz.JobDataMap;
@@ -98,6 +99,8 @@ public class RetryJobListener extends JobListenerSupport {
     }
 
     private ZonedDateTime calculateNextScheduledDate() {
-        return dateTimeProvider.now().plusSeconds(durationInSeconds);
+        int randomSeconds = new SecureRandom().nextInt(0, 120);
+        // To avoid concurrency issues, add random seconds with max 2 minutes
+        return dateTimeProvider.now().plusSeconds(durationInSeconds + randomSeconds);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/timedevent/infrastructure/services/quartz/RetryJobListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/timedevent/infrastructure/services/quartz/RetryJobListenerTest.java
@@ -3,6 +3,7 @@ package uk.gov.hmcts.reform.timedevent.infrastructure.services.quartz;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -115,6 +116,7 @@ class RetryJobListenerTest {
         assertEquals(jurisdiction, timedEvent.getValue().getJurisdiction());
         assertEquals(caseType, timedEvent.getValue().getCaseType());
         assertEquals(Event.EXAMPLE, timedEvent.getValue().getEvent());
-        assertEquals(dateTime.plusSeconds(durationInSeconds), timedEvent.getValue().getScheduledDateTime());
+        assertTrue(timedEvent.getValue().getScheduledDateTime()
+                .isBefore(dateTime.plusSeconds(durationInSeconds + 121)));
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/timedevent/infrastructure/services/quartz/RetryJobListenerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/timedevent/infrastructure/services/quartz/RetryJobListenerTest.java
@@ -3,7 +3,6 @@ package uk.gov.hmcts.reform.timedevent.infrastructure.services.quartz;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
-import java.time.Duration;
 import java.time.ZonedDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DIAC-835

### Change description
When IA service was down, the scheduled events that didn't run were all re-scheduled to the same time and causing 409 errors when there were more than 1 event scheduled for same appeal. 
Add random value between 0-120 seconds to the reschedule time to avoid these issues

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
