### PR TITLE
DIAC-2168 - Bump Application Insights agent version to 3.7.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
  # renovate: datasource=github-releases depName=microsoft/ApplicationInsights-Java
-ARG APP_INSIGHTS_AGENT_VERSION=3.4.18
+ARG APP_INSIGHTS_AGENT_VERSION=3.7.3
 
 # Application image
 


### PR DESCRIPTION
Aligns with the version used by ia-case-api and other IA services for consistent telemetry collection across the platform.